### PR TITLE
Fix Qtech.QSW and TPLink.T2600G get_version scripts

### DIFF
--- a/sa/profiles/Qtech/QSW/get_version.py
+++ b/sa/profiles/Qtech/QSW/get_version.py
@@ -24,7 +24,7 @@ class Script(BaseScript):
     )
     rx_bootprom = re.compile(r"^bootrom version\s+:\s+V(?P<bootprom>\S*)$", re.MULTILINE)
     rx_hardware = re.compile(r"^hardware version\s+:\s+V(?P<hardware>\S+)$", re.MULTILINE)
-    rx_serial = re.compile(r"^product serial number\s+:\s+(?P<serial>\S+)$", re.MULTILINE)
+    rx_serial = re.compile(r"^product serial (number|no\.)\s+:\s+(?P<serial>\S+)$", re.MULTILINE)
 
     rx_plat1 = re.compile(r"^\s+(?P<platform>QSW-\S+) Device, Compiled on", re.MULTILINE)
     rx_plat2 = re.compile(r"^\s+Device: (?P<platform>QSW-\S+), sysLocation:", re.MULTILINE)

--- a/sa/profiles/TPLink/T2600G/get_version.py
+++ b/sa/profiles/TPLink/T2600G/get_version.py
@@ -13,7 +13,7 @@ from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetversion import IGetVersion
 
 rx_platform = re.compile(r"\s+Hardware Version\s+- (?P<platform>.+?)\n")
-rx_version = re.compile(r"\s+Software Version\s+- (?P<version>.+?)\n")
+rx_version = re.compile(r"\s+(Soft|Firm)ware Version\s+- (?P<version>.+?)\n")
 
 
 class Script(BaseScript):


### PR DESCRIPTION
switch#show version
software platform   : QTECH Broadband Network Platform Software
software version    : QTECH QSW-2910-10T-POE V100R001B01D005P003SP16
copyright           : Copyright (C) 2001-2018 By QTECH Co., LLC.
compiled time       : Mar 19 2019, 10:35:30
processor           : ARM v5TE, 333MHz
SDRAM(bytes)        : 64M
flash memory(bytes) : 8M
MAC address         : 08:c6:b3:14:f6:3c
product serial no.  : 1803500247
hardware version    : V2.0
bootrom version     : V1.5.14

switch#